### PR TITLE
Use c_str instead of string for boost::filesystem::path::const_iterat…

### DIFF
--- a/src/common/bu/ResourceManager.cc
+++ b/src/common/bu/ResourceManager.cc
@@ -536,7 +536,7 @@ void evb::bu::ResourceManager::updateDiskUsages()
     boost::filesystem::path::const_iterator pathIter = path.begin();
     while ( pathIter != path.end() )
     {
-      if ( boost::algorithm::icontains(pathIter->string(),"ramdisk") )
+      if ( boost::algorithm::icontains(pathIter->c_str(),"ramdisk") )
       {
         ramDiskSizeInGB_ = (*it)->diskSizeGB();
         ramDiskUsed_ = (*it)->relDiskUsage();


### PR DESCRIPTION
…or. This works also for older boost versions