### PR TITLE
added support for specifying the XDAQ log level on the command line

### DIFF
--- a/test/scripts/runScans.py
+++ b/test/scripts/runScans.py
@@ -40,6 +40,7 @@ class RunScans(TestRunner):
         parser.add_argument("--ferolMode",action='store_true',help="generate data on FEROL instead of FRL")
         parser.add_argument("--scaleFedSizesFromFile",help="scale the FED fragment sizes relative to the sizes in the given file")
         parser.add_argument("--calculateFedSizesFromFile",help="calculate the FED fragment sizes using the parameters in the given file")
+        parser.add_argument("--logLevel", type = str, default = None, help="set XDAQ log level")
 
 
     def fillFedSizeScalesFromFile(self):
@@ -137,6 +138,7 @@ class RunScans(TestRunner):
                 config = ConfigFromFile(self._symbolMap,configFile,self.args['fixPorts'],self.args['numa'],
                                             self.args['generateAtRU'],self.args['dropAtRU'],self.args['dropAtSocket'],ferolMode)
                 configCase = ConfigCase(config,stdout,self.fedSizeScaleFactors)
+                configCase.setXdaqLogLevel(self.args['logLevel'])
                 configCase.prepare(configName)
                 for fragSize in sizes:
                     fragSizeRMS = int(fragSize * self.args['rms'])


### PR DESCRIPTION
with the command line option `--logLevel`. Useful to specify `DEBUG` loglevel for the xdaq applications. 