### PR TITLE
XMLRPC support for xdaqLauncher

### DIFF
--- a/test/scripts/Context.py
+++ b/test/scripts/Context.py
@@ -159,6 +159,12 @@ class BU(Context):
         self.applications.append(app)
 
 
+def resetInstanceNumbers():
+    # resets all instance numbers of the above classes
+    # (these are class wide / static variables)
+    FEROL.instance = 0
+    RU.instance = 0
+    BU.instance = 0
 
 if __name__ == "__main__":
     os.environ["EVB_SYMBOL_MAP"] = 'standaloneSymbolMap.txt'

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -43,7 +43,7 @@ def startXDAQ(context,testname,logLevel):
     if logLevel is not None:
         server.setLogLevel(context.hostinfo['soapPort'],logLevel)
 
-    ret += messengers.sendCmdToLauncher("startXDAQ",context.hostinfo['soapHostname'],context.hostinfo['launcherPort'],context.hostinfo['soapPort'],testname)
+    ret += server.startXDAQ(context.hostinfo['soapPort'],testname)
     return ret
 
 
@@ -126,7 +126,7 @@ class TestCase:
 
     def startXDAQs(self,testname):
         try:
-            results = [self._pool.apply_async(startXDAQ, args=(c,testname, self._xdaqLogLevel)) for c in self._config.contexts.values()]
+            results = [self._xmlrpc_pool.apply_async(startXDAQ, args=(c,testname, self._xdaqLogLevel)) for c in self._config.contexts.values()]
             for r in results:
                 try:
                     print(r.get(timeout=30))

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -301,7 +301,9 @@ class TestCase:
         try:
             for application in self._config.applications[app]:
                 if instance is None or str(instance) == application['instance']:
-                    files.extend( eval(messengers.sendCmdToLauncher("getFiles",application['soapHostname'],application['launcherPort'],application['soapPort'],dir)) )
+                    server = xmlrpclib.ServerProxy("http://%s:%s" % (application['soapHostname'],application['launcherPort']))
+
+                    files.extend( eval(server.getFiles(application['soapPort'],dir)) )
         except KeyError:
             pass
         return [f for f in files if re.search(regex,f)]

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -88,6 +88,14 @@ class TestCase:
         sys.stdout = stdout
         self._config = config
         self._pool = mp.Pool(20,init_worker)
+
+        # standard multiprocessing pool does not work well with exceptions
+        # over xmlrpc, so we use a pool based on threads (instead of procecesses)
+        # for xmlrpc operations (we are mostly waiting for IO so this should 
+        # not be a problem for performance)
+        from multiprocessing.pool import ThreadPool
+        self._xmlrpc_pool = ThreadPool(20)
+
         self._xdaqLogLevel = None
 
 

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -101,7 +101,7 @@ class TestCase:
         # for xmlrpc operations (we are mostly waiting for IO so this should 
         # not be a problem for performance)
         from multiprocessing.pool import ThreadPool
-        self._xmlrpc_pool = ThreadPool(20)
+        self._xmlrpcPool = ThreadPool(20)
 
         self._xdaqLogLevel = None
 
@@ -112,7 +112,7 @@ class TestCase:
         except OSError:
             pass
         if self._config:
-            results = [self._xmlrpc_pool.apply_async(stopXDAQ, args=(c,)) for c in self._config.contexts.values()]
+            results = [self._xmlrpcPool.apply_async(stopXDAQ, args=(c,)) for c in self._config.contexts.values()]
             for r in results:
                 print(r.get(timeout=30))
         self._pool.close()
@@ -126,7 +126,7 @@ class TestCase:
 
     def startXDAQs(self,testname):
         try:
-            results = [self._xmlrpc_pool.apply_async(startXDAQ, args=(c,testname, self._xdaqLogLevel)) for c in self._config.contexts.values()]
+            results = [self._xmlrpcPool.apply_async(startXDAQ, args=(c,testname, self._xdaqLogLevel)) for c in self._config.contexts.values()]
             for r in results:
                 try:
                     print(r.get(timeout=30))

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -38,8 +38,10 @@ import xmlrpclib
 def startXDAQ(context,testname,logLevel):
     ret = "Starting XDAQ on "+context.hostinfo['soapHostname']+":"+str(context.hostinfo['launcherPort'])+"\n"
 
+    server = xmlrpclib.ServerProxy("http://%s:%s" % (context.hostinfo['soapHostname'],context.hostinfo['launcherPort']))
+
     if logLevel is not None:
-        messengers.sendCmdToLauncher("setLogLevel",context.hostinfo['soapHostname'],context.hostinfo['launcherPort'],context.hostinfo['soapPort'],logLevel)
+        server.setLogLevel(context.hostinfo['soapPort'],logLevel)
 
     ret += messengers.sendCmdToLauncher("startXDAQ",context.hostinfo['soapHostname'],context.hostinfo['launcherPort'],context.hostinfo['soapPort'],testname)
     return ret

--- a/test/scripts/TestRunner.py
+++ b/test/scripts/TestRunner.py
@@ -97,4 +97,7 @@ class TestRunner:
         for launcher in self._symbolMap.launchers:
             if self.args['verbose']:
                 print("Stopping launcher on "+launcher[0]+":"+str(launcher[1]))
-            messengers.sendCmdToLauncher("stopLauncher",launcher[0],launcher[1])
+
+            import xmlrpclib
+            server = xmlrpclib.ServerProxy("http://%s:%s" % (launcher[0],launcher[1]))
+            server.stopLauncher()

--- a/test/scripts/messengers.py
+++ b/test/scripts/messengers.py
@@ -20,25 +20,6 @@ class SOAPexception(Exception):
     pass
 
 
-def sendCmdToLauncher(cmd,soapHostname,launcherPort,soapPort=None,testname=""):
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect((soapHostname,int(launcherPort)))
-        if soapPort is None:
-            s.send(cmd+" "+testname)
-        else:
-            s.send(cmd+':'+soapPort+" "+testname)
-        response = []
-        while True:
-            reply = s.recv(1024)
-            if not reply: break
-            response.append(reply)
-        s.close()
-        return ''.join(response)
-    except socket.error as e:
-        return "Failed to contact launcher: "+e.strerror
-
-
 def webPing(soapHostname,soapPort):
     code = None
     try:

--- a/test/scripts/runTests.py
+++ b/test/scripts/runTests.py
@@ -10,6 +10,7 @@ from Configuration import Configuration
 from TestRunner import TestRunner,Tee,BadConfig
 from SymbolMap import SymbolMap
 from TestCase import TestCase
+import Context
 
 
 class RunTests(TestRunner):
@@ -84,6 +85,8 @@ class RunTests(TestRunner):
 
 
     def runTest(self,test,stdout):
+        Context.resetInstanceNumbers()
+
         try:
             testModule = __import__(test,fromlist=test)
             testCase = getattr(testModule,'case_'+test)

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -110,24 +110,21 @@ class xdaqLauncher:
 
 
     def startXDAQ(self,port,testname):
-        if self.server.logDir and testname is None:
-            self.request.sendall("Please specify a testname")
-            return
+
+        if self.logDir and testname is None:
+            raise Exception("Please specify a testname")
         if port is None:
-            self.request.sendall("Please specify a port number")
-            return
+            raise Exception("Please specify a port number")
         if port in xdaqLauncher.threads and xdaqLauncher.threads[port].is_alive():
-            self.request.sendall("There is already a XDAQ process running on port "+str(port))
-            return
+            raise Exception("There is already a XDAQ process running on port "+str(port))
         self.cleanTempFiles()
         try:
-            thread = xdaqThread(port,self.getLogFile(testname),self.server.useNuma, self.server.logLevel, self.server.dummyXdaq)
+            thread = xdaqThread(port,self.getLogFile(testname),self.useNuma, self.logLevel, self.dummyXdaq)
             thread.start()
         except KeyError:
-            self.request.sendall("Please specify XDAQ_ROOT")
-            return
+            raise Exception("Please specify XDAQ_ROOT")
         xdaqLauncher.threads[port] = thread
-        self.request.sendall("Started XDAQ on port "+str(port))
+        return "Started XDAQ on port "+str(port)
 
 
     def killProcess(self,port):

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -160,13 +160,17 @@ class xdaqLauncher:
             self.request.sendall(response)
 
 
-    def stopLauncher(self,port,args):
+    def stopLauncher(self):
         response = ""
         for port in xdaqLauncher.threads.keys():
             response += self.killProcess(port)+"\n"
         response += "Terminating launcher"
-        self.request.sendall(response)
-        threading.Thread(target = self.server.shutdown).start()
+
+        # tell the XML rpc server to stop serving requests
+        if not self.xmlrpc_server is None:
+            self.xmlrpc_server.stop = True
+
+        return response
 
 
     def getFiles(self,port,dir):
@@ -203,6 +207,10 @@ if __name__ == "__main__":
     server.server_activate()
 
     launcher = xdaqLauncher(logDir = args['logDir'], useNuma = useNuma, dummyXdaq = args['dummyXdaq'])
+
+    # add the server to the xdaqLauncher object
+    # so that it can set the stop flag
+    launcher.xmlrpc_server = server
 
     # for the moment we prefer to register methods individually
     # rather than calling register_instance() which registers

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -82,7 +82,7 @@ class xdaqLauncher:
 
     def __init__(self, logDir, useNuma, dummyXdaq):
 
-        self.xmlrpc_server = None
+        self.xmlrpcServer = None
 
         self.logDir = logDir
         self.useNuma = useNuma
@@ -163,8 +163,8 @@ class xdaqLauncher:
         response += "Terminating launcher"
 
         # tell the XML rpc server to stop serving requests
-        if not self.xmlrpc_server is None:
-            self.xmlrpc_server.stop = True
+        if not self.xmlrpcServer is None:
+            self.xmlrpcServer.stop = True
 
         return response
 
@@ -205,7 +205,7 @@ if __name__ == "__main__":
 
     # add the server to the xdaqLauncher object
     # so that it can set the stop flag
-    launcher.xmlrpc_server = server
+    launcher.xmlrpcServer = server
 
     # for the moment we prefer to register methods individually
     # rather than calling register_instance() which registers

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -103,8 +103,8 @@ class xdaqLauncher:
 
 
     def getLogFile(self,testname):
-        if self.server.logDir:
-            return self.server.logDir+"/"+testname+"-"+socket.gethostname()+".log"
+        if self.logDir:
+            return self.logDir+"/"+testname+"-"+socket.gethostname()+".log"
         else:
             return None
 

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -10,7 +10,16 @@ import sys
 import threading
 import SocketServer
 
+from SimpleXMLRPCServer import SimpleXMLRPCServer
 
+class ExitableServer(SimpleXMLRPCServer):
+    # an XMLRPC server which can exit
+    
+    def serve_forever(self):
+        self.stop = False
+        while not self.stop:
+            self.handle_request()
+            
 class xdaqThread(threading.Thread):
 
     def __init__(self,xdaqPort,logFile,useNuma, logLevel, dummyXdaq):

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -174,9 +174,8 @@ class xdaqLauncher:
 
     def getFiles(self,port,dir):
         if dir is None:
-            self.request.sendall("Please specify a directory")
-            return
-        self.request.sendall( str(os.listdir(dir)) )
+            raise Exception("Please specify a directory")
+        return str(os.listdir(dir))
 
     def setLogLevel(self, port, level):
         # sets the XDAQ log level for the given application

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -177,10 +177,10 @@ class xdaqLauncher:
             raise Exception("Please specify a directory")
         return str(os.listdir(dir))
 
-    def setLogLevel(self, port, level):
+    def setLogLevel(self, level):
         # sets the XDAQ log level for the given application
         # this must be called before starting the XDAQ process in question
-        self.server.logLevel = level
+        self.logLevel = level
 
 
 if __name__ == "__main__":

--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -142,7 +142,7 @@ class xdaqLauncher:
             return "XDAQ process on port "+str(port)+" does not exist"
 
 
-    def stopXDAQ(self,port,args):
+    def stopXDAQ(self,port):
         response = ""
         self.cleanTempFiles()
         if port is None:
@@ -152,12 +152,11 @@ class xdaqLauncher:
             try:
                 response = self.killProcess(port)
             except KeyError:
-                self.request.sendall("There is no XDAQ processes on port "+str(port))
-                return
+                raise Exception("There is no XDAQ processes on port "+str(port))
         if response == "":
-            self.request.sendall("There are no running XDAQ processes")
+            return "There are no running XDAQ processes"
         else:
-            self.request.sendall(response)
+            return response
 
 
     def stopLauncher(self):


### PR DESCRIPTION
changed xdaqLauncher such that it is controlled via XMLRPC (using python's XMLRPC library) as opposed to a custom telnet like protocol like it was used before.