### PR TITLE
more detailed error message when xdaqLauncher port is already in use 

### DIFF
--- a/test/scripts/xdaqLauncher.py
+++ b/test/scripts/xdaqLauncher.py
@@ -198,7 +198,15 @@ if __name__ == "__main__":
                             bind_and_activate = False,
                             logRequests = False)
     server.allow_reuse_address = True
-    server.server_bind()
+    try:
+        server.server_bind()
+    except socket.error, ex:
+        import errno
+        if ex.errno == errno.EADDRINUSE:
+            raise Exception("xdaq launcher address already in use on %s:%s" % (hostname, args['port']))
+        else:
+            raise
+
     server.server_activate()
 
     launcher = xdaqLauncher(logDir = args['logDir'], useNuma = useNuma, dummyXdaq = args['dummyXdaq'])


### PR DESCRIPTION
added information about which host and port a xdaqLauncher can not bind the socket such that it is easier to identify where an xdaqLauncher is left over from a previous test