### PR TITLE
improvements for stopping xdaq processes

### DIFF
--- a/test/scripts/ConfigCase.py
+++ b/test/scripts/ConfigCase.py
@@ -13,8 +13,8 @@ class ConfigCase(TestCase):
         self.defaultFedSize = defaultFedSize
 
 
-    def __del__(self):
-        TestCase.__del__(self)
+    def destroy(self):
+        TestCase.destroy(self)
 
 
     def calculateFedSize(self,fedId,fragSize,fragSizeRMS):

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -120,9 +120,7 @@ class TestCase:
         except OSError:
             pass
         if self._config:
-            results = [self._xmlrpcPool.apply_async(stopXDAQ, args=(c,)) for c in self._config.contexts.values()]
-            for r in results:
-                print(r.get(timeout=30))
+            self.stopXDAQs()
         self._pool.close()
         self._pool.join()
         sys.stdout.flush()
@@ -131,6 +129,18 @@ class TestCase:
 
     def setXdaqLogLevel(self, newLevel):
         self._xdaqLogLevel = newLevel
+
+    def stopXDAQs(self):
+        # stops all XDAQ processes we started before
+        import logging
+        logging.info("stopping all XDAQs")
+
+        results = [self._xmlrpcPool.apply_async(stopXDAQ, args=(c,)) for c in self._config.contexts.values()]
+        for r in results:
+            print(r.get(timeout=30))
+        
+        logging.info("done stopping all XDAQs")
+
 
     def startXDAQs(self,testname):
         try:

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -114,7 +114,7 @@ class TestCase:
         self._xdaqLogLevel = None
 
 
-    def __del__(self):
+    def destroy(self):
         try:
             shutil.rmtree("/tmp/evb_test")
         except OSError:

--- a/test/scripts/runBenchmarks.py
+++ b/test/scripts/runBenchmarks.py
@@ -127,7 +127,7 @@ class RunBenchmarks(TestRunner):
         testCase.prepare(benchmark)
 
         self.scanFedSizes(benchmark,testCase)
-        del(testCase)
+        testCase.destroy()
 
 
 if __name__ == "__main__":

--- a/test/scripts/runScans.py
+++ b/test/scripts/runScans.py
@@ -121,7 +121,7 @@ class RunScans(TestRunner):
             traceback.print_exc(file=stdout)
             returnValue = "\033[1;37;41m FAILED \033[0m "+type(e).__name__+": "+str(e)
         finally:
-            del(configCase)
+            configCase.destroy()
             if not self.args['symbolMap']:
                 self.stopLaunchers()
         return returnValue


### PR DESCRIPTION
- renamed `__del__` methods in `TestCase.py` and `ConfigCase.py` to `destroy()` since it is not guaranteed when garbage collection of objects happens (and therefore when xdaq processes are stopped), see e.g. https://stackoverflow.com/a/1481512/288875
- factored out a new method stopXDAQs() in class TestCase