### PR TITLE
support for callback after event builder startup complete

### DIFF
--- a/test/scripts/ConfigCase.py
+++ b/test/scripts/ConfigCase.py
@@ -7,8 +7,8 @@ from TestCase import *
 
 class ConfigCase(TestCase):
 
-    def __init__(self,config,stdout,fedSizeScaleFactors,defaultFedSize):
-        TestCase.__init__(self,config,stdout)
+    def __init__(self,config,stdout,fedSizeScaleFactors,defaultFedSize,afterStartupCallback = None):
+        TestCase.__init__(self,config,stdout, afterStartupCallback = afterStartupCallback)
         self.fedSizeScaleFactors = fedSizeScaleFactors
         self.defaultFedSize = defaultFedSize
 

--- a/test/scripts/TestCase.py
+++ b/test/scripts/TestCase.py
@@ -98,11 +98,20 @@ def init_worker():
 
 class TestCase:
 
-    def __init__(self,config,stdout):
+    def __init__(self,config,stdout,afterStartupCallback = None):
+        """
+        @param afterStartupCallback is a callback which will be called
+        after the EVB has been enabled when nbMeasurements is zero.
+        If this is left None, the user is prompted to press enter
+        to terminate the test. This function is called with the
+        TestCase object as argument.
+        """
+
         self._origStdout = sys.stdout
         sys.stdout = stdout
         self._config = config
         self._pool = mp.Pool(20,init_worker)
+        self.afterStartupCallback = afterStartupCallback
 
         # standard multiprocessing pool does not work well with exceptions
         # over xmlrpc, so we use a pool based on threads (instead of procecesses)
@@ -797,8 +806,11 @@ class TestCase:
         if args['nbMeasurements'] == 0:
             dataPoints.append( self.getDataPoint() )
 
-            # run until the user presses enter
-            raw_input("Press Enter to stop...")
+            if self.afterStartupCallback is None:
+                # run until the user presses enter
+                raw_input("Press Enter to stop...")
+            else:
+                self.afterStartupCallback(self)
 
         else:
             if args['long']:

--- a/test/scripts/runScans.py
+++ b/test/scripts/runScans.py
@@ -17,6 +17,10 @@ class RunScans(TestRunner):
     def __init__(self):
         TestRunner.__init__(self)
 
+        # callback passed to TestCase to be called when startup is complete
+        # and the number of measurements is zero
+        self.afterStartupCallback = None
+
     def addOptions(self,parser):
         TestRunner.addOptions(self,parser)
         TestRunner.addScanOptions(self,parser)
@@ -30,6 +34,8 @@ class RunScans(TestRunner):
         parser.add_argument("--scaleFedSizesFromFile",help="scale the FED fragment sizes relative to the sizes in the given file")
         parser.add_argument("--calculateFedSizesFromFile",help="calculate the FED fragment sizes using the parameters in the given file")
 
+    def setAfterStartupCallback(self, afterStartupCallback):
+        self.afterStartupCallback = afterStartupCallback
 
     def fillFedSizeScalesFromFile(self):
         self.fedSizeScaleFactors = {}
@@ -84,7 +90,7 @@ class RunScans(TestRunner):
         return True
 
 
-    def runConfig(self,configName,configFile,stdout):
+    def runConfig(self,configName,configFile,stdout, afterStartupCallback = None):
         try:
             #----------
             # symbol map / configuration to run
@@ -108,7 +114,8 @@ class RunScans(TestRunner):
                 ferolMode = 'FRL_MODE'
             config = ConfigFromFile(self._symbolMap,configFile,self.args['fixPorts'],self.args['numa'],
                                     self.args['generateAtRU'],self.args['dropAtRU'],self.args['dropAtSocket'],ferolMode)
-            configCase = ConfigCase(config,stdout,self.fedSizeScaleFactors,self.defaultFedSize)
+            configCase = ConfigCase(config,stdout,self.fedSizeScaleFactors,self.defaultFedSize, 
+                                    afterStartupCallback = self.afterStartupCallback)
             configCase.setXdaqLogLevel(self.args['logLevel'])
             configCase.prepare(configName)
 


### PR DESCRIPTION
Added support for a callback in class `TestCase` which is called after the startup of the event builder is complete when `nbMeasurements` is zero instead of prompting the user to press enter (which is still the default if no callback is given). 

Event building is halted once the callback returns. This callback is used in the XDAQ workloop assignment optimization to check if one or more XDAQ Applications went into failed state and restart the setup if necessary.

This callback solution looks a bit like a workaround but a cleaner solution would require some more thinking and more reorganization of the code (which we can do in the future).

----

This is the last pull request with modifications needed in shared code (i.e. code not exclusively used for running XDAQ workloop assignment optimization). A pull request with the code used for the optimization should follow soon.