### PR TITLE
adding Context.resetInstanceNumbers() in RunBenchmarks.getConfiguration()

### DIFF
--- a/test/scripts/runBenchmarks.py
+++ b/test/scripts/runBenchmarks.py
@@ -9,7 +9,7 @@ from Configuration import Configuration
 from TestRunner import TestRunner,Tee,BadConfig
 from SymbolMap import SymbolMap
 from TestCase import TestCase
-from Context import Context,RU,BU,RUBU
+from Context import Context,RU,BU,RUBU, resetInstanceNumbers
 
 
 class RunBenchmarks(TestRunner):
@@ -61,6 +61,8 @@ class RunBenchmarks(TestRunner):
 
 
     def getConfiguration(self):
+        resetInstanceNumbers()
+
         config = Configuration(self._symbolMap,self.args['numa'])
         # EVM
         config.add( RU(self._symbolMap,[


### PR DESCRIPTION
in `RunBenchmarks.getConfiguration()`: now calling `Context.resetInstanceNumbers()` to make it possible to call this method more than once (before this change, instance numbers did not start at the beginning when calling this function a second time)