### PR TITLE
support for retrieving last CPU of workloops

### DIFF
--- a/test/scripts/optim/WorkLoopData.py
+++ b/test/scripts/optim/WorkLoopData.py
@@ -235,4 +235,28 @@ class WorkLoopData:
 
     #----------------------------------------
 
+    def getCurrentThreadPinnings(self):
+        """:return a dict of canonical work loop name to the CPU core number
+        where the thread last ran"""
+
+        result = {}
+
+        if self.workLoopToPid is None:
+            # not yet set
+            return result
+
+        # collect the list of all PIDs to look at
+        pids = list(self.workLoopToPid.values())
+
+        # pinnings will be a map of pid -> last CPU used
+        # (note that the pids will be strings, not ints)
+        lastCpus = self.rpcclient.getLastCpuOfProcesses(pids)
+
+        # map back from pids to work loop names
+        for wln, pid in self.workLoopToPid.items():
+            result[wln] = lastCpus[str(pid)]
+
+        return result
+
+
 #----------------------------------------------------------------------

--- a/test/scripts/optim/WorkLoopList.py
+++ b/test/scripts/optim/WorkLoopList.py
@@ -114,4 +114,25 @@ class WorkLoopList:
 
     #----------------------------------------
 
+    def getCurrentThreadPinnings(self):
+        """:return a nested dict with information about the work loop
+        to cpu core assignments.
+        The first index is the application type (e.g. RU),
+        the second index is a tuple (soap host, soap port)
+        the third index is the (canonical) work loop name
+        the value is the cpu core this work loop was last found running on
+        """
+        result = {}
 
+        for appType, workLoopDatas in self.workLoopDatas.items():
+
+            thisResult = {}
+
+            for workLoopData in workLoopDatas:
+                key = (workLoopData.soapHost, workLoopData.soapPort)
+
+                thisResult[key] = workLoopData.getCurrentThreadPinnings()
+
+            result[appType] = thisResult
+
+        return result


### PR DESCRIPTION
this adds a method to xdaqLauncher to retrieve the last CPU a workloop was run on given the thread (process) id

(also adds corresponding methods on the client side to retrieve this from all known xdaq applications during the optimization)