### PR TITLE
better initialization of thread to core assignments

### DIFF
--- a/test/scripts/optim/DeapRunner.py
+++ b/test/scripts/optim/DeapRunner.py
@@ -68,7 +68,7 @@ class DeapRunner:
                               len(self.parameterNames) # number of parameters per individual
                 )
 
-        self.toolbox.register("population", tools.initRepeat, list, self.toolbox.individual)
+        self.toolbox.register("population", self.initializeFromCurrentStateClones, list, self.toolbox.individual)
 
         # register our custom mapping function with some instrumentation to keep track
         # of generation and evaluation index within the generation
@@ -196,6 +196,11 @@ class DeapRunner:
 
         # keep track of the initial rate before tuning was started
         # to be able to print improvements in each log message
+
+        sleepTime = 30
+        logging.info("sleeping %d seconds before retrieving initial performance" % sleepTime)
+        time.sleep(sleepTime)
+
         self.initialRateMean, self.initialRateStd, lastRate = self.goalFunction.getEventRate()
         logging.info("readout rate before tuning: %.1f +/- %.1f kHz" % (self.initialRateMean / 1e3, self.initialRateStd / 1e3))
 

--- a/test/scripts/optim/DeapRunner.py
+++ b/test/scripts/optim/DeapRunner.py
@@ -7,12 +7,13 @@ class DeapRunner:
     # for optimizing the work loop to core assignments
 
     def __init__(self, coreNumbers, goalFunction, resultFname = None, evbRunner = None):
-        # configures the genetic algorithm toolbox
-        # 
-        # @param coreNumbers is the list of core numbers which can be
-        # used to pin these threads to
-        #
-        # @param goalFunction must be an instance of GoalFunctionDeap
+        """configures the genetic algorithm toolbox
+
+        :param coreNumbers: is the list of core numbers which can be
+                           used to pin these threads to
+
+        :param goalFunction: must be an instance of GoalFunctionDeap
+        """
 
         # the function which pins the threads
         self.goalFunction = goalFunction

--- a/test/scripts/optim/DeapRunner.py
+++ b/test/scripts/optim/DeapRunner.py
@@ -144,8 +144,8 @@ class DeapRunner:
 
         from deap import creator
 
-        for i in range(n):
-            # create a n times the same individual
+        for i in range(n / 2):
+            # create a n/2 times the same individual
 
             indiv = []
 
@@ -153,6 +153,16 @@ class DeapRunner:
                 indiv.append(paramNameToCores[param])
 
             population.append(creator.Individual(indiv))
+
+        for i in range(n/2, n):
+            # create the rest with random initializations
+            indiv = []
+
+            for param in self.parameterNames:
+                indiv.append(self.toolbox.attr_core())
+
+            population.append(creator.Individual(indiv))
+
 
         return containerType(population)
 


### PR DESCRIPTION
with these modifications, the code will
- first wait 30 seconds after starting the event builder
- then retrieve the CPU core assignments of all workloops to be optimized
- generate an initial population which consists of:
  - the first half corresponds to the assignment corresponding to the first instance (in a dict) of each application type 
  - the second half is still randomly initialized